### PR TITLE
compatibility improvement 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "e7awgsw"
-version = "1.0.0"
+version = "1.1.0"
 description = "e7awg manipulator"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
20240125 より前の simple_multi_ のファームウェアとの互換性対策です。
以前のファームウェアに対して、enable_dsp() が無効なアドレスを叩くだけで無害なのかもしれませんが、褒められた方法ではないので、それなりの対策をしておきます。

- QuEL側で、バージョン情報や対象製品の型番などに基づいて `enable_dsp_enable` を操作しますので、それに相当する機能をe7awgsw側に実装するのは、とりあえず無しの方向で。
    - enable_dsp_enable が True であれば、CaptureCtrl.initialize() で、デフォルトで dsp_enable() する挙動になっています。
  
- labrad 側は特に対策をしていないです。同様の手法で引数を追加するのがよいと思います。必要なら対応をお願いします。
- テストが通ったら、PRのDraftを外します。