### PR TITLE
Update pylabrad to 0.98.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 dependencies = [
   "numpy==1.26.0",
   "matplotlib==3.8.0",
-  "pylabrad==0.98.2",
+  "pylabrad==0.98.3",
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
This should resolve the following installation issue: https://github.com/e-trees/e7awg_sw/issues/16

町野さんから simplemulti_standard に向けたPRを頂きました。
(simplemulti_standard, simplemulti_classic には適用済みです。)

こちらにも適用するべきだと思います。
